### PR TITLE
Fix scheduler timing accuracy - make jobs run at exact scheduled time

### DIFF
--- a/SellerMarket/scheduler.py
+++ b/SellerMarket/scheduler.py
@@ -53,28 +53,17 @@ class JobScheduler:
             now = datetime.now()
             current_time = now.time()
             
-            # Create a time window (30 seconds before to 30 seconds after)
-            job_datetime = datetime.combine(now.date(), job_time)
-            window_start = (job_datetime - timedelta(seconds=30)).time()
-            window_end = (job_datetime + timedelta(seconds=30)).time()
-            
-            # Check if current time is within window
-            if window_start <= window_end:
-                # Normal case: window doesn't cross midnight
-                in_window = window_start <= current_time <= window_end
-            else:
-                # Midnight crossing case: window spans midnight
-                in_window = current_time >= window_start or current_time <= window_end
-            
-            if not in_window:
-                return False
-            
             # Check if already executed today
             job_key = f"{job['name']}_{now.date().isoformat()}"
             if job_key in self.executed_today:
                 return False
             
-            return True
+            # Check if current time is at or after the scheduled time
+            # This ensures jobs run at the exact scheduled time or very close to it
+            if current_time >= job_time:
+                return True
+            
+            return False
             
         except Exception as e:
             logger.error(f"Error checking job schedule: {e}")


### PR DESCRIPTION
It's related to #14  issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved job scheduling precision by removing the time window mechanism. Jobs now trigger at their exact scheduled time rather than within a flexible window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->