### PR TITLE
feat(locust): #15 add market open timing constraint

### DIFF
--- a/SellerMarket/locustfile_new.py
+++ b/SellerMarket/locustfile_new.py
@@ -233,7 +233,8 @@ def prepare_order_data(config_section: dict) -> Dict[str, Any]:
         api_client=api_client
     )
 
-
+# Market open timing threshold (parsed once at module level)
+MARKET_OPEN_THRESHOLD = datetime.strptime('08:44:58.500', '%H:%M:%S.%f').time()
 class TradingUser(HttpUser):
     """Base Locust user for trading operations."""
     
@@ -264,10 +265,9 @@ class TradingUser(HttpUser):
         # Fast timing check: skip orders before market open timing window
         # Broker API has 300ms penalty per ISIN per person during high demand
         now = datetime.now().time()
-        market_open_threshold = datetime.strptime('08:44:58.500', '%H:%M:%S.%f').time()
-        if now < market_open_threshold:
+        if now < MARKET_OPEN_THRESHOLD:
             return  # Skip order, mark task as completed
-        
+
         # Get logger with file handler for this task
         task_logger = logging.getLogger(__name__)
         


### PR DESCRIPTION
Broker API imposes 300ms penalty per ISIN per person during high-demand periods when many traders place orders at market open (08:45:00). This feature ensures orders are only sent after 08:44:58.500 to avoid rate limiting penalties.

The timing check is performed at the start of each order placement task:
- Before 08:44:58.500: Orders are skipped (task completes without sending request)
- At/after 08:44:58.500: Orders proceed normally

This allows the bot to start early (e.g., at 08:44:30) but wait for the optimal timing window to avoid broker API penalties during peak demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Order processing now respects a market-open timing gate: submissions are skipped until the market is open and proceed thereafter.
  * Improved logging for order attempts and outcomes to make submission results clearer and easier to audit.
  * Network and request errors during order submission are now caught and logged to reduce silent failures.
  * No changes to public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->