### PR TITLE
Add support for IbTrader broker (ib)

### DIFF
--- a/SellerMarket/broker_enum.py
+++ b/SellerMarket/broker_enum.py
@@ -39,7 +39,7 @@ class BrokerCode(Enum):
     def get_endpoints(self) -> dict:
         """Get API endpoints for this broker."""
         domain = "ibtrader.ir" if self.value == "ib" else "ephoenix.ir"
-        prefix = "" if self.value == "ib" else f"-{self.value}."
+        prefix = "." if self.value == "ib" else f"-{self.value}."
         return {
             'captcha': f'https://identity{prefix}{domain}/api/Captcha/GetCaptcha',
             'login': f'https://identity{prefix}{domain}/api/v2/accounts/login',


### PR DESCRIPTION

Added support for IbTrader broker with code 'ib' and domain 'ibtrader.ir'.

Closes #24

Updated BrokerCode enum to include IBTRADER, modified get_broker_name and get_endpoints methods.
For IbTrader, URLs use direct domain without broker code prefix:
- https://identity.ibtrader.ir/api/Captcha/GetCaptcha
- https://api.ibtrader.ir/api/v2/orders/NewOrder

For other brokers, maintains the standard format with '-' prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how service hostnames are constructed for brokers, improving consistency across integrations.
  * Adjusted hostname pattern for one broker to match expected identity endpoint format, reducing connection inconsistencies.
  * Other trading and account endpoints now follow the unified pattern for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->