### PR TITLE
Add Ayandeh broker support (#34)

### DIFF
--- a/SellerMarket/broker_enum.py
+++ b/SellerMarket/broker_enum.py
@@ -18,6 +18,7 @@ class BrokerCode(Enum):
     IBTRADER = "ib"  # IbTrader
     HAMERZ = "hbc"  # Hamerz
     RABIN = "rabin"  # Rabin
+    AYANDEH = "ayandeh"
     
     @classmethod
     def get_broker_name(cls, code: str) -> str:
@@ -31,7 +32,8 @@ class BrokerCode(Enum):
             "ebb": "EBB",
             "ib": "IbTrader",
             "hbc": "Hamerz",
-            "rabin": "Rabin"
+            "rabin": "Rabin",
+            "ayandeh": "Ayandeh"
         }
         return names.get(code, code)
     


### PR DESCRIPTION
## Summary

- Add `AYANDEH = "ayandeh"` enum member to `BrokerCode` in `broker_enum.py`
- Add `"ayandeh": "Ayandeh"` entry to the `get_broker_name` lookup dictionary
- Normalized enum member name to uppercase convention (`AYANDEH`) consistent with other brokers

Closes #34

## Test plan

- [x] Verify `BrokerCode.AYANDEH.value == "ayandeh"`
- [x] Verify `BrokerCode.get_broker_name("ayandeh") == "Ayandeh"`
- [x] Verify `BrokerCode.is_valid("ayandeh")` returns `True`
- [x] Verify `BrokerCode.AYANDEH.get_endpoints()` returns correct `ephoenix.ir` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)